### PR TITLE
Fix rendering issues when code blocks are in a bullet point item

### DIFF
--- a/lib/isodoc/csd/html/htmlstyle.scss
+++ b/lib/isodoc/csd/html/htmlstyle.scss
@@ -541,10 +541,10 @@ ul > li {
     display: inline-block; width: 1em;
     margin-left: -1.2em;
   }
-  
-  li p:first-child {
-    display: inline;
-  }
+
+li p:first-child {
+  display: inline;
+}
 
 li:first-child {
   margin-top: 1em;

--- a/lib/isodoc/csd/html/htmlstyle.scss
+++ b/lib/isodoc/csd/html/htmlstyle.scss
@@ -542,7 +542,7 @@ ul > li {
     margin-left: -1.2em;
   }
   
-  li p {
+  li p:first-child {
     display: inline;
   }
 


### PR DESCRIPTION
E.g., given an Asciidoc source:

```asciidoc
something something

* Enter something:
+
[source,bash]
----
test
----

* something:
+
[source,bash]
----
test
----
```

## Result (screenshot)

![failure](https://user-images.githubusercontent.com/2649467/45861130-9d37e000-bd9d-11e8-98b7-589ec0f9e8dd.png)

## Expected result (screenshot)

![success](https://user-images.githubusercontent.com/2649467/45861229-03bcfe00-bd9e-11e8-85ae-7f6510c5b5a6.png)
